### PR TITLE
fix(mfe): do not share hookform resolvers

### DIFF
--- a/apps/dashboard/module-federation.config.js
+++ b/apps/dashboard/module-federation.config.js
@@ -1,7 +1,6 @@
 const deps = require('../../package.json').dependencies;
 
 const sharedLibraries = new Set([
-  '@hookform/resolvers',
   'react',
   'react-dom',
   'react-hook-form',

--- a/apps/login/module-federation.config.js
+++ b/apps/login/module-federation.config.js
@@ -1,6 +1,17 @@
+const sharedLibraries = new Set([
+  '@hookform/resolvers',
+  '@hookform/resolvers/yup',
+]);
+
 module.exports = {
   name: 'login',
   exposes: {
     './Module': './src/remote-entry.ts',
+  },
+  shared: (library, defaultConfig) => {
+    console.log(library);
+    if (sharedLibraries.has(library)) {
+      return false;
+    }
   },
 };


### PR DESCRIPTION
Ensure `@hookform/resolvers` are not shared. They do not need to be and they cause issues with Module Federation
